### PR TITLE
#11 APIアクセスにトークン認証を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'bcrypt', '~> 3.1.7'
 # アクセスコード発行用
 gem 'public_uid'
 
+# 環境変数設定用
+gem 'dotenv-rails'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
       rake (< 13.0)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     ffi (1.11.1)
     globalid (0.4.2)
@@ -210,6 +214,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  dotenv-rails
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      before_action :auth_token
+
       def index
         render json: { status: 'SUCCESS', data: User.all }
       end
@@ -36,6 +38,18 @@ module Api
             render json: { status: 'FAILED', data: @user }
           end
         end
+      end
+
+      private
+
+      def auth_token
+        errobj = { status: 'FORBIDDEN', data: {
+          "message": "access denied."
+        } }
+        jptime = Time.zone.now
+        seed = jptime.mon.to_s + jptime.day.to_s + ENV['TOKEN_SECRET']
+        hash = Digest::MD5.hexdigest(seed)
+        render json: errobj unless params[:token] == hash
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Otofudanet
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
## 概要

- すべてのAPIアクセスにトークン認証を必須化
- `.env`ファイルが必要

close #11 
