### PR TITLE
デッキまわりのUIなど

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+@import "decks";
+
 body {
   background: #303030;
   color: #f0f0f0;

--- a/app/assets/stylesheets/decks.scss
+++ b/app/assets/stylesheets/decks.scss
@@ -1,3 +1,32 @@
 // Place all the styles related to the decks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.button-black { //デッキ削除ボタン用
+  color: #f0f0f0;
+  background: #444444;
+  border: 1px solid #a0a0a0;
+}
+.button-blue {
+  background: #42b8dd;
+  cursor: default;
+}
+
+.card-list{ // 札一覧用
+  display: flex;
+  flex-flow: row wrap;
+  width: 100%;
+  @media screen and (max-width:720px) { // スマホ用
+    flex-flow: column nowrap;
+  }
+  .item{ // 札と説明文のセット
+    flex-basis: 23%;
+    margin: 1%;
+    img{
+      height: 150px;
+    }
+    p{
+      margin: 0 1em;
+    }
+  }
+}

--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -3,7 +3,7 @@ class DecksController < ApplicationController
 
   def index
     @user = account
-    @decks = @user.decks
+    @decks = @user.decks.order("created_at")
   end
   
   def show

--- a/app/views/decks/_form.html.erb
+++ b/app/views/decks/_form.html.erb
@@ -4,19 +4,19 @@
 
 <%= render "errors", obj:@deck %>
 
-<table>
-  <tr>
-    <th><%= f.label :name, "デッキ名" %></th>
-    <td colspan="5"><%= f.text_field :name %></td>
-  </tr>
-  <tr>
-    <th>月</th>
-    <td><%= f.select :slot1, options %></td>
-    <td><%= f.select :slot2, options %></td>
-    <td><%= f.select :slot3, options %></td>
-    <td><%= f.select :slot4, options %></td>
-    <td><%= f.select :slot5, options %></td>
-  </tr>
+<div class="m-m">
+  <div class="row">
+    <h4><%= f.label :name, "デッキ名" %></h4>
+    <%= f.text_field :name %>
+  </div>
+  <div class="row">
+    <h4>構成月</h4>
+    <%= f.select :slot1, options %>
+    <%= f.select :slot2, options %>
+    <%= f.select :slot3, options %>
+    <%= f.select :slot4, options %>
+    <%= f.select :slot5, options %>
+  </div>
   <%= f.hidden_field :user_id, value: @deck.user_id %>
   <%= f.hidden_field :status, value: @deck.status %>
-</table>
+</div>

--- a/app/views/decks/index.html.erb
+++ b/app/views/decks/index.html.erb
@@ -7,16 +7,15 @@
 
 <% if @decks.present? %>
   <% @decks.each do |d| %>
-    <div>
+    <div class="kit-pane dark hover m-m">
       <h4><%= link_to "#{d.name.blank? ? '名称未設定のデッキ' : d.name}", d %></h4>
-      <p>
-        構成月：<%= d.slot1 %>月 <%= d.slot2 %>月 <%= d.slot3 %>月 <%= d.slot4 %>月 <%= d.slot5 %>月<br>
-        <% if d.sub? %>
-          <%= link_to "使うデッキにする", [:change_status, d], method: :patch %> / <%= link_to "デッキ削除", d, method: :delete %>
-        <% else # statusがmainの時 %>
-          <%= "*選択中のデッキ*" %>
-        <% end %>
-      </p>
+      構成月：<%= d.slot1 %>月 <%= d.slot2 %>月 <%= d.slot3 %>月 <%= d.slot4 %>月 <%= d.slot5 %>月<br>
+      <% if d.sub? %>
+        <%= link_to "使うデッキにする", [:change_status, d], method: :patch, class: "pure-button" %>   
+        <%= link_to "デッキ削除", d, method: :delete, class: "pure-button button-black" %>
+      <% else # statusがmainの時 %>
+        <a class="pure-button button-blue"><%= "*選択中のデッキ*" %></a>
+      <% end %>
     </div>
   <% end %>
 <% else %>

--- a/app/views/decks/show.html.erb
+++ b/app/views/decks/show.html.erb
@@ -1,23 +1,27 @@
 <% @page_title = "デッキ詳細" %>
 
 <h3><%= @deck.name.blank? ? "名称未設定のデッキ" : @deck.name %></h3>
+
+<div class="m-m p-m kit-font-l">
+  <h4>構成月</h4>
+  <%= @deck.slot1 %>月 <%= @deck.slot2 %>月 <%= @deck.slot3 %>月 <%= @deck.slot4 %>月 <%= @deck.slot5 %>月
+</div>
+
 <%= link_to ">デッキ情報を編集する", [:edit, @deck] %>
 
-<div>
-  <h4>構成</h4>
-  <p>
-    <%= @deck.slot1 %>月 <%= @deck.slot2 %>月 <%= @deck.slot3 %>月 <%= @deck.slot4 %>月 <%= @deck.slot5 %>月
-  </p>
+<div class="m-m">
+  <h4>構成札一覧</h4>
+  <div class="card-list">
+    <% @cards.each do |c| %>
+      <div class="item kit-font-s">
+        <img src="<%= c.image %>"><br>
+        <p><%= c.effect_text %></p>
+      </div>
+    <% end %>
+  </div>
 </div>
 
-<div>
-  <h4>構成札一覧</h4>
-  <% @cards.each do |c| %>
-    <div>
-    <img src="<%= c.image %>" style="height:150px">
-    <p><%= c.month %>月 / <%= c.name %> / <%= c.point %>点 (<%= c.identifier %>)</p>
-    <p><%= c.effect_label %></p>
-    <p><%= c.effect_text %></p>
-    </div>
-  <% end %>
-</div>
+
+<a href="https://www.ne.senshu-u.ac.jp/~proj2019-13/fuda" target="_blank" rel=”noopener noreferrer” class="p-m">
+  <i class="fas fa-external-link-alt"></i>より詳しい札の情報はこちらから
+</a>

--- a/app/views/decks/show.html.erb
+++ b/app/views/decks/show.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "デッキ詳細" %>
+
 <h3><%= @deck.name.blank? ? "名称未設定のデッキ" : @deck.name %></h3>
 <%= link_to ">デッキ情報を編集する", [:edit, @deck] %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,6 +121,9 @@
           <a href="/users/enterac">
             <i class="fas fa-id-card"></i>カード登録
           </a>
+          <a href="/songs">
+            <i class="fas fa-music"></i>楽曲リスト
+          </a>
         <% end%>
       </nav>
       <main><%= yield %></main>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -20,7 +20,7 @@
     <%= link_to( "ログアウト", "/sessions/" + account&.id.to_s, method: :delete ) %>
 <% end %>
 <div class="m">
-    <a href="/songs" class="pure-button">楽曲一覧</a>
+    <a href="/songs" class="pure-button">楽曲リスト</a>
     <br>
     <br>
     <a href="/howto">おとふだNETへの初回登録方法</a>


### PR DESCRIPTION
### UI関係
- デッキリストの表示を整形
- デッキリストを作った順(created_at)に並び替え
- デッキ詳細ページの札リストを整形
- new/editのフォームの整形

### PC表示
![スクリーンショット 2020-11-27 21 48 10](https://user-images.githubusercontent.com/46423355/100451181-51f68600-30fa-11eb-8a05-864f3c88b1a8.png)
![スクリーンショット 2020-11-27 21 47 56](https://user-images.githubusercontent.com/46423355/100451189-54f17680-30fa-11eb-997d-eab1263c92b1.png)

### スマホ(ブラウザ幅 720pxまで)表示
![スクリーンショット 2020-11-27 21 47 45](https://user-images.githubusercontent.com/46423355/100451193-5622a380-30fa-11eb-922c-c487f029c6e1.png)


### その他
- 楽曲リストのリンクを非ログイン状態でも表示
- 「楽曲一覧」→「楽曲リスト」に統一
- deck#showでページタイトル設定が抜けていたのを修正
- デッキ詳細ページの札リストの情報量が少ないのでここにも公式サイトへのリンクを置いといた

close #48 